### PR TITLE
Update Client.php

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -22,7 +22,7 @@ class Client
      *
      * @var string
      */
-    public $gateway = 'https://gw.vipapis.com';
+    public $gateway = 'https://vop.vipapis.com';
 
     /**
      * AppKey


### PR DESCRIPTION
渠道切换域名通知！！！唯品会开放平台VOP应安全要求： 将于2023年5月31日下线https://vipapis.com及https://gw.vipapis.com两个入口地址，只保留https://vop.vipapis.com域名。其他域名的请求都会失效，请还没切换的渠道及时切换到最新域名